### PR TITLE
Split up workflow into multiple jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,18 @@ on:
     types: [created]
 
 jobs:
-  publish-to-testflight:
+  build-app:
+    name: Build iOS app
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Set up Node
+        uses: actions/setup-node@v1
         with:
           node-version: 12
-      - uses: expo/expo-github-action@v6
+          cache: yarn
+      - name: Set up Expo
+        uses: expo/expo-github-action@v6
         with:
           expo-version: 4.x
           username: ${{secrets.EXPO_CLI_USERNAME}}
@@ -22,9 +26,33 @@ jobs:
         env:
           EXPO_APPLE_ID: ${{secrets.EXPO_APPLE_ID}}
           EXPO_APPLE_PASSWORD: ${{secrets.EXPO_APPLE_PASSWORD}}
-      - run: curl -O `expo url:ipa`
-      - run: gem install fastlane -N
-      - run: fastlane pilot upload
+  fetch-binary:
+    name: Fetch binary
+    runs-on: macos-latest
+    needs: build-app
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download from Expo
+        run: curl -O `expo url:ipa`
+      - name: Upload binary as artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: binary
+          path: *.ipa
+  publish-to-testflight:
+    name: Publish to TestFlight
+    runs-on: macos-latest
+    needs: [build-app, download-binary]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download binary from artifacts
+        uses: actions/download-artifact@v2.0.10
+        with:
+          name: binary
+      - name: Install fastlane
+        run: gem install fastlane -N
+      - name: Upload to fastlane
+        run: fastlane pilot upload
         env:
             FASTLANE_USER: ${{secrets.EXPO_APPLE_ID}}
             FASTLANE_PASSWORD: ${{secrets.EXPO_APPLE_PASSWORD}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,11 +38,11 @@ jobs:
         uses: actions/upload-artifact@v2.2.4
         with:
           name: binary
-          path: *.ipa
+          path: '*.ipa'
   publish-to-testflight:
     name: Publish to TestFlight
     runs-on: macos-latest
-    needs: [build-app, download-binary]
+    needs: [build-app, fetch-binary]
     steps:
       - uses: actions/checkout@v2
       - name: Download binary from artifacts


### PR DESCRIPTION
For finer control over each step of the publication process. The gist of
how this works is:

1. Build and publish the app via Expo
2. Download the binary from Expo
3. Upload the binary as an artifact
4. Push the artifact to Fastlane

It's a lot of uploading and downloading but because this is broken up in
multiple jobs, we don't have to risk restarting the entire process if
something fails in between. Instead, we could re-run the specific job
that we need.
