### PR TITLE
Cache Expo installation so that it's available for other jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
         uses: expo/expo-github-action@v6
         with:
           expo-version: 4.x
+          expo-cache: true
           username: ${{secrets.EXPO_CLI_USERNAME}}
           password: ${{secrets.EXPO_CLI_PASSWORD}}
       - run: yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to TestFlight
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build-app:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-app:
     name: Build iOS app
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node
@@ -29,7 +29,7 @@ jobs:
           EXPO_APPLE_PASSWORD: ${{secrets.EXPO_APPLE_PASSWORD}}
   fetch-binary:
     name: Fetch binary
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: build-app
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
See [here](https://github.com/expo/expo-github-action#cache-expo-cli-for-other-jobs) for more info about the `expo-cache` option.

Other changes in this PR includes:
- changing the VM OS for the first couple of jobs
- adding the option to trigger the workflow manually