### PR TITLE
Handle _buffer_cleared to fix duplicate lines

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,19 @@ jobs:
           cache: yarn
       - run: yarn install
       - run: yarn test
+  tsc:
+    name: Run tsc
+    runs-on: ubuntu-latest
+    needs: cache-and-test
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
+      - run: yarn install
+      - run: yarn tsc
   linter:
     name: Run linter
     runs-on: ubuntu-latest

--- a/src/lib/weechat/action_transformer.ts
+++ b/src/lib/weechat/action_transformer.ts
@@ -1,10 +1,5 @@
 import { StoreState } from '../../store';
 
-export type WeechatReduxAction = {
-  type: string;
-  payload: any;
-};
-
 type KeyFn<T> = (t: T) => string;
 type MapFn<A, B> = (a: A) => A | B;
 
@@ -58,7 +53,10 @@ export const transformToReduxAction = (data: WeechatResponse<unknown>) => {
       const object = data.objects[0] as WeechatObject<{ full_name: string }[]>;
       const fullName = object.content[0].full_name;
 
-      return (dispatch, getState) => {
+      return (
+        dispatch: (action: object) => void,
+        getState: () => StoreState
+      ) => {
         const state: StoreState = getState();
         const buffer = Object.values(state.buffers).find(
           (buffer: WeechatBuffer) => buffer.full_name == fullName
@@ -76,7 +74,10 @@ export const transformToReduxAction = (data: WeechatResponse<unknown>) => {
       const object = data.objects[0] as WeechatObject<WeechatLine[]>;
       const line = object.content[0];
 
-      return (dispatch, getState) => {
+      return (
+        dispatch: (action: object) => void,
+        getState: () => StoreState
+      ) => {
         const state: StoreState = getState();
 
         dispatch({
@@ -144,7 +145,10 @@ export const transformToReduxAction = (data: WeechatResponse<unknown>) => {
     case 'hotlist': {
       const object = data.objects[0] as WeechatObject<WeechatHotlist[]>;
 
-      return (dispatch, getState) => {
+      return (
+        dispatch: (action: object) => void,
+        getState: () => StoreState
+      ) => {
         const state: StoreState = getState();
 
         dispatch({

--- a/src/store/buffers.ts
+++ b/src/store/buffers.ts
@@ -2,41 +2,47 @@ export type BufferState = { [key: string]: WeechatBuffer };
 
 const initialState: BufferState = {};
 
-export default (state: BufferState = initialState, action): BufferState => {
+export default (
+  state: BufferState = initialState,
+  action: { type: string; bufferId: string; payload: unknown }
+): BufferState => {
   switch (action.type) {
-    case "FETCH_BUFFERS": {
-      return action.payload;
+    case 'FETCH_BUFFERS': {
+      return action.payload as BufferState;
     }
-    case "BUFFER_CLOSED": {
-      return Object.fromEntries(Object.entries(state)
-        .filter(([bufferId]) => bufferId !== action.bufferId));
+    case 'BUFFER_CLOSED': {
+      return Object.fromEntries(
+        Object.entries(state).filter(
+          ([bufferId]) => bufferId !== action.bufferId
+        )
+      );
     }
-    case "BUFFER_OPENED": {
+    case 'BUFFER_OPENED': {
       return {
         ...state,
-        [action.bufferId]: action.payload
+        [action.bufferId]: action.payload as WeechatBuffer
       };
     }
-    case "BUFFER_LOCALVAR_UPDATE": {
+    case 'BUFFER_LOCALVAR_UPDATE': {
       return {
         ...state,
         [action.bufferId]: {
           ...state[action.bufferId],
           local_variables: {
             ...state[action.bufferId].local_variables,
-            ...action.payload.local_variables
+            ...(action.payload as WeechatBuffer).local_variables
           }
         }
       };
     }
-    case "BUFFER_LOCALVAR_REMOVE": {
+    case 'BUFFER_LOCALVAR_REMOVE': {
       if (state[action.bufferId]) {
         return {
           ...state,
           [action.bufferId]: {
             ...state[action.bufferId],
             local_variables: {
-              ...action.payload.local_variables
+              ...(action.payload as WeechatBuffer).local_variables
             }
           }
         };
@@ -44,13 +50,13 @@ export default (state: BufferState = initialState, action): BufferState => {
         return state;
       }
     }
-    case "BUFFER_RENAMED": {
+    case 'BUFFER_RENAMED': {
       return {
         ...state,
         [action.bufferId]: {
           ...state[action.bufferId],
-          full_name: action.payload.full_name,
-          short_name: action.payload.short_name
+          full_name: (action.payload as WeechatBuffer).full_name,
+          short_name: (action.payload as WeechatBuffer).short_name
         }
       };
     }

--- a/src/store/connection-info.ts
+++ b/src/store/connection-info.ts
@@ -12,16 +12,25 @@ const initialState: ConnectionInfo = {
   filterBuffers: true
 };
 
-export default (state: ConnectionInfo = initialState, action): ConnectionInfo => {
+export default (
+  state: ConnectionInfo = initialState,
+  action: {
+    type: string;
+    hostname: string;
+    password: string;
+    ssl: boolean;
+    filterBuffers: boolean;
+  }
+): ConnectionInfo => {
   switch (action.type) {
-    case "SET_CONNECTION_INFO":
+    case 'SET_CONNECTION_INFO':
       return {
         hostname: action.hostname,
         password: action.password,
         ssl: action.ssl,
         filterBuffers: action.filterBuffers
       };
-    case "CLEAR_CONNECTION_INFO":
+    case 'CLEAR_CONNECTION_INFO':
       return initialState;
     default:
       return state;

--- a/src/store/hotlists.ts
+++ b/src/store/hotlists.ts
@@ -1,22 +1,36 @@
-import { getHotlistForBufferId } from "./selectors";
+import { getHotlistForBufferId } from './selectors';
 
 export type HotListState = { [key: string]: Hotlist };
 
 const initialState: HotListState = {};
 
-export default (state: HotListState = initialState, action): HotListState => {
+export default (
+  state: HotListState = initialState,
+  action: {
+    type: string;
+    currentBufferId: string;
+    payload: unknown;
+    bufferId: string;
+  }
+): HotListState => {
   switch (action.type) {
-    case "FETCH_HOTLISTS":
+    case 'FETCH_HOTLISTS':
       if (action.currentBufferId) {
-        return Object.fromEntries(Object.entries(<HotListState> action.payload)
-          .filter(([bufferId]) => bufferId !== action.currentBufferId));
+        return Object.fromEntries(
+          Object.entries(<HotListState>action.payload).filter(
+            ([bufferId]) => bufferId !== action.currentBufferId
+          )
+        );
       }
 
-      return action.payload;
-    case "CHANGE_CURRENT_BUFFER":
-      return Object.fromEntries(Object.entries(state)
-        .filter(([bufferId]) => bufferId !== action.bufferId));
-    case "BUFFER_LINE_ADDED": {
+      return action.payload as HotListState;
+    case 'CHANGE_CURRENT_BUFFER':
+      return Object.fromEntries(
+        Object.entries(state).filter(
+          ([bufferId]) => bufferId !== action.bufferId
+        )
+      );
+    case 'BUFFER_LINE_ADDED': {
       if (action.bufferId === action.currentBufferId) {
         return state;
       }
@@ -26,9 +40,8 @@ export default (state: HotListState = initialState, action): HotListState => {
         ...getHotlistForBufferId(state, action.bufferId)
       };
 
-      const shouldNotify = (tag) => (
-        tag != "irc_smart_filter" && tag != "notify_none"
-      );
+      const shouldNotify = (tag: string) =>
+        tag != 'irc_smart_filter' && tag != 'notify_none';
       if (payload.tags_array.every(shouldNotify)) {
         if (payload.highlight !== 0) {
           hotlist.highlight++;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -29,7 +29,10 @@ const initialState: AppState = {
   currentBufferId: null
 };
 
-const app = (state: AppState = initialState, action) => {
+const app = (
+  state: AppState = initialState,
+  action: { type: string; bufferId: string }
+) => {
   switch (action.type) {
     case 'DISCONNECT':
       return {

--- a/src/store/lines.ts
+++ b/src/store/lines.ts
@@ -4,16 +4,25 @@ const initialState: LineState = {};
 
 export default (state: LineState = initialState, action): LineState => {
   switch (action.type) {
-    case "FETCH_LINES":
+    case 'FETCH_LINES':
       return {
         ...state,
         [action.bufferId]: action.payload
       };
-    case "BUFFER_CLOSED": {
-      return Object.fromEntries(Object.entries(state)
-        .filter(([bufferId]) => bufferId !== action.bufferId));
+    case 'BUFFER_CLOSED': {
+      return Object.fromEntries(
+        Object.entries(state).filter(
+          ([bufferId]) => bufferId !== action.bufferId
+        )
+      );
     }
-    case "BUFFER_LINE_ADDED":
+    case 'BUFFER_CLEARED': {
+      return {
+        ...state,
+        [action.bufferId]: []
+      };
+    }
+    case 'BUFFER_LINE_ADDED':
       return {
         ...state,
         [action.bufferId]: [action.payload, ...(state[action.bufferId] || [])]

--- a/src/store/lines.ts
+++ b/src/store/lines.ts
@@ -2,12 +2,15 @@ export type LineState = { [key: string]: WeechatLine[] };
 
 const initialState: LineState = {};
 
-export default (state: LineState = initialState, action): LineState => {
+export default (
+  state: LineState = initialState,
+  action: { type: string; bufferId: string; payload: unknown }
+): LineState => {
   switch (action.type) {
     case 'FETCH_LINES':
       return {
         ...state,
-        [action.bufferId]: action.payload
+        [action.bufferId]: action.payload as WeechatLine[]
       };
     case 'BUFFER_CLOSED': {
       return Object.fromEntries(
@@ -25,7 +28,10 @@ export default (state: LineState = initialState, action): LineState => {
     case 'BUFFER_LINE_ADDED':
       return {
         ...state,
-        [action.bufferId]: [action.payload, ...(state[action.bufferId] || [])]
+        [action.bufferId]: [
+          action.payload as WeechatLine,
+          ...(state[action.bufferId] || [])
+        ]
       };
     default:
       return state;

--- a/src/store/nicklists.ts
+++ b/src/store/nicklists.ts
@@ -2,30 +2,39 @@ export type NicklistState = { [key: string]: WeechatNicklist[] };
 
 const initialState: NicklistState = {};
 
-export default (state: NicklistState = initialState, action): NicklistState => {
+export default (
+  state: NicklistState = initialState,
+  action: { type: string; payload: unknown; bufferId: string }
+): NicklistState => {
   switch (action.type) {
-    case "FETCH_NICKLIST":
+    case 'FETCH_NICKLIST':
       return {
         ...state,
-        [action.bufferId]: action.payload
+        [action.bufferId]: action.payload as WeechatNicklist[]
       };
-    case "NICK_ADDED": {
+    case 'NICK_ADDED': {
       return {
         ...state,
-        [action.bufferId]: [...(state[action.bufferId] || []), action.payload]
+        [action.bufferId]: [
+          ...(state[action.bufferId] || []),
+          action.payload as WeechatNicklist
+        ]
       };
     }
-    case "NICK_REMOVED": {
+    case 'NICK_REMOVED': {
       return {
         ...state,
         [action.bufferId]: (state[action.bufferId] || []).filter(
-          nick => nick.name !== action.payload.name
+          (nick) => nick.name !== (action.payload as WeechatNicklist).name
         )
       };
     }
-    case "BUFFER_CLOSED": {
-      return Object.fromEntries(Object.entries(state)
-        .filter(([bufferId]) => bufferId !== action.bufferId));
+    case 'BUFFER_CLOSED': {
+      return Object.fromEntries(
+        Object.entries(state).filter(
+          ([bufferId]) => bufferId !== action.bufferId
+        )
+      );
     }
     default:
       return state;


### PR DESCRIPTION
When a buffer is cleared it's possible that a pointer is reused. This causes issues with the Buffer FlatList keyExtractor, which expects unique values for the key.

wee-slack clears the buffer when loading a buffer or after reconnecting. This would cause out of order messages and errors in development mode.

Fixes #12.