### PR TITLE
Disallow smart quotes by specifying keyboardType

### DIFF
--- a/src/usecase/settings/UploadSettings.tsx
+++ b/src/usecase/settings/UploadSettings.tsx
@@ -174,6 +174,7 @@ const UploadSettings: React.FC<Props> = ({
             autoCapitalize="none"
             placeholder="RegExp (default: /^https://\S+/)"
             autoCorrect={false}
+            keyboardType="ascii-capable"
             onChangeText={setUploadOptionsRegexp}
             value={uploadOptionsState.regexp}
           />


### PR DESCRIPTION
iOS tries to use smart quotes where possible, which can cause issues
when we're trying to extract the URL image with regex. Setting
`keyboardType` to `ascii-capable` should now force regular quotation
marks instead.

before|after
---|---
![smart quotes](https://github.com/mhoran/weechatRN/assets/602470/e6eb3865-5b8f-47ea-bb79-5262f5f0b1b5)|![regular quotes](https://github.com/mhoran/weechatRN/assets/602470/7ed5be78-75b7-4501-b1e4-8cc5a3676611)
