### PR TITLE
Attempt to reconnect when brought to foreground

### DIFF
--- a/__tests__/lib/weechat/connection.ts
+++ b/__tests__/lib/weechat/connection.ts
@@ -93,7 +93,7 @@ describe(WeechatConnection, () => {
     expect(dispatch).toHaveBeenCalledWith(fetchVersionAction('4.1.2'));
   });
 
-  describe('close', () => {
+  describe('disconnect', () => {
     it('closes the WebSocket', () => {
       const dispatch = jest.fn();
       const connection = new WeechatConnection(
@@ -115,12 +115,10 @@ describe(WeechatConnection, () => {
         )
       } as WebSocketMessageEvent);
 
-      connection.close();
+      connection.disconnect();
 
-      expect(mockWebSocket.mock.instances[0].send).toHaveBeenCalledWith(
-        'quit\n'
-      );
       expect(mockWebSocket.mock.instances[0].close).toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledTimes(2);
       expect(dispatch).toHaveBeenNthCalledWith(2, disconnectAction());
       expect(mockWebSocket.mock.instances).toHaveLength(1);
     });
@@ -150,6 +148,7 @@ describe(WeechatConnection, () => {
       mockWebSocket.mock.instances[0].close();
 
       expect(onError).toHaveBeenCalledWith(true, ConnectionError.Socket);
+      expect(dispatch).toHaveBeenCalledTimes(2);
       expect(dispatch).toHaveBeenNthCalledWith(2, disconnectAction());
       expect(mockWebSocket.mock.instances).toHaveLength(2);
     });

--- a/src/usecase/ConnectionGate.tsx
+++ b/src/usecase/ConnectionGate.tsx
@@ -1,6 +1,7 @@
-import { connect } from 'react-redux';
-import { StoreState } from '../store';
+import { useEffect } from 'react';
+import { connect, useStore } from 'react-redux';
 import { ConnectionError } from '../lib/weechat/connection';
+import { StoreState } from '../store';
 import SettingsNavigator from './settings/SettingsNavigator';
 
 interface Props {
@@ -18,6 +19,19 @@ const ConnectionGate: React.FC<Props> = ({
   onConnect,
   connectionError
 }) => {
+  const store = useStore<StoreState>();
+
+  useEffect(() => {
+    const connectionSettings = store.getState().connection;
+    if (connectionSettings.hostname && connectionSettings.password) {
+      onConnect(
+        connectionSettings.hostname,
+        connectionSettings.password,
+        connectionSettings.ssl
+      );
+    }
+  }, [onConnect, store]);
+
   if (connected) {
     return children;
   } else {


### PR DESCRIPTION
Previous reconnect logic works well when in the foreground, but not when in the background. We now always attempt to reconnect when foregrounded.