### PR TITLE
Don't unnecessarily fetch lines for notification

### DIFF
--- a/__tests__/usecase/App.tsx
+++ b/__tests__/usecase/App.tsx
@@ -5,10 +5,7 @@ import { act, render } from '../../src/test-utils';
 import { configureStore } from '@reduxjs/toolkit';
 import { reducer } from '../../src/store';
 import { AppState } from '../../src/store/app';
-import {
-  bufferNotificationAction,
-  changeCurrentBufferAction
-} from '../../src/store/actions';
+import { bufferNotificationAction } from '../../src/store/actions';
 
 jest.mock('react-native-drawer-layout');
 
@@ -67,60 +64,6 @@ describe('App', () => {
       expect(store.getState().app.currentBufferId).toEqual(bufferId);
       expect(clearHotlistForBuffer).toHaveBeenCalledWith(null);
       expect(fetchBufferInfo).toHaveBeenCalledWith(bufferId);
-    });
-
-    it('fetches buffer info if the notification is for the current buffer', () => {
-      const bufferId = '86c417600';
-      const store = configureStore({
-        reducer,
-        preloadedState: {
-          buffers: {
-            [bufferId]: {
-              full_name: 'irc.libera.#weechat',
-              hidden: 0,
-              id: bufferId,
-              local_variables: {
-                channel: '#weechat',
-                name: 'libera.#weechat',
-                plugin: 'irc',
-                type: 'channel'
-              },
-              notify: 3,
-              number: 2,
-              pointers: [bufferId],
-              short_name: '#weechat',
-              title: '',
-              type: 0
-            }
-          }
-        }
-      });
-      const fetchBufferInfo = jest.fn();
-      const clearHotlistForBuffer = jest.fn();
-
-      render(
-        <App
-          disconnect={() => {}}
-          fetchBufferInfo={fetchBufferInfo}
-          sendMessageToBuffer={() => {}}
-          clearHotlistForBuffer={clearHotlistForBuffer}
-        />,
-        { store }
-      );
-
-      act(() => {
-        store.dispatch(changeCurrentBufferAction(bufferId));
-        store.dispatch(
-          bufferNotificationAction({
-            bufferId,
-            lineId: '8580dcc40',
-            identifier: '1fb4fc1d-530b-466f-85be-de27772de0a9'
-          })
-        );
-      });
-
-      expect(fetchBufferInfo).toHaveBeenCalledWith(bufferId);
-      expect(clearHotlistForBuffer).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/usecase/buffers/ui/Buffer.tsx
+++ b/__tests__/usecase/buffers/ui/Buffer.tsx
@@ -54,6 +54,7 @@ describe(Buffer, () => {
           parseArgs={[]}
           bufferId={''}
           fetchMoreLines={() => {}}
+          clearNotification={() => {}}
         />
       );
 

--- a/__tests__/usecase/buffers/ui/BufferContainer.tsx
+++ b/__tests__/usecase/buffers/ui/BufferContainer.tsx
@@ -1,6 +1,7 @@
 import 'react-native';
+import Buffer from '../../../../src/usecase/buffers/ui/Buffer';
 import BufferContainer from '../../../../src/usecase/buffers/ui/BufferContainer';
-import { act, render } from '../../../../src/test-utils';
+import { act, render, screen } from '../../../../src/test-utils';
 import { reducer } from '../../../../src/store';
 import { configureStore } from '@reduxjs/toolkit';
 import {
@@ -8,12 +9,15 @@ import {
   changeCurrentBufferAction,
   fetchLinesAction
 } from '../../../../src/store/actions';
-import Buffer from '../../../../src/usecase/buffers/ui/Buffer';
 
-jest.mock('.../../../../src/usecase/buffers/ui/Buffer');
+jest.mock('../../../../src/usecase/buffers/ui/Buffer');
 
 describe('BufferContainer', () => {
-  it('scrolls to line and clears notification after fetching lines', () => {
+  beforeEach(() => {
+    jest.mocked(Buffer).mockImplementation();
+  });
+
+  it('defers notification until buffer change and line fetch', () => {
     const bufferId = '86c417600';
     const store = configureStore({
       reducer,
@@ -40,8 +44,6 @@ describe('BufferContainer', () => {
       }
     });
 
-    Buffer.prototype.scrollToLine = jest.fn();
-
     render(
       <BufferContainer
         bufferId={bufferId}
@@ -52,20 +54,29 @@ describe('BufferContainer', () => {
       { store }
     );
 
+    const bufferContainer = screen.UNSAFE_getByType(
+      BufferContainer.WrappedComponent
+    );
+
     act(() => {
       store.dispatch(
         bufferNotificationAction({
           bufferId,
-          lineId: '8580dcc40',
+          lineId: '86c2ff040',
           identifier: '1fb4fc1d-530b-466f-85be-de27772de0a9'
         })
       );
     });
 
-    expect(Buffer.prototype.scrollToLine).not.toHaveBeenCalled();
+    expect(bufferContainer.props.notification).toBeNull();
 
     act(() => {
       store.dispatch(changeCurrentBufferAction(bufferId));
+    });
+
+    expect(bufferContainer.props.notification).toBeNull();
+
+    act(() => {
       store.dispatch(
         fetchLinesAction([
           {
@@ -83,7 +94,97 @@ describe('BufferContainer', () => {
       );
     });
 
-    expect(Buffer.prototype.scrollToLine).toHaveBeenCalledWith('8580dcc40');
+    expect(bufferContainer.props.notification).toEqual({
+      bufferId,
+      lineId: '86c2ff040',
+      identifier: '1fb4fc1d-530b-466f-85be-de27772de0a9'
+    });
+  });
+
+  it('clears notification after being handled by the buffer component', () => {
+    const ActualBuffer = jest.requireActual<
+      typeof import('../../../../src/usecase/buffers/ui/Buffer')
+    >('../../../../src/usecase/buffers/ui/Buffer').default;
+    jest.mocked(Buffer).mockImplementation((props) => {
+      return new ActualBuffer(props);
+    });
+    jest.spyOn(ActualBuffer.prototype, 'componentDidUpdate');
+
+    const bufferId = '86c417600';
+    const store = configureStore({
+      reducer,
+      preloadedState: {
+        buffers: {
+          [bufferId]: {
+            full_name: 'irc.libera.#weechat',
+            hidden: 0,
+            id: bufferId,
+            local_variables: {
+              channel: '#weechat',
+              name: 'libera.#weechat',
+              plugin: 'irc',
+              type: 'channel'
+            },
+            notify: 3,
+            number: 2,
+            pointers: [bufferId],
+            short_name: '#weechat',
+            title: '',
+            type: 0
+          }
+        }
+      }
+    });
+
+    render(
+      <BufferContainer
+        bufferId={bufferId}
+        showTopic={false}
+        sendMessage={() => {}}
+        fetchMoreLines={() => {}}
+      />,
+      { store }
+    );
+
+    act(() => {
+      store.dispatch(
+        bufferNotificationAction({
+          bufferId,
+          lineId: '86c2ff040',
+          identifier: '1fb4fc1d-530b-466f-85be-de27772de0a9'
+        })
+      );
+    });
+
+    expect(store.getState().app.notification).not.toBeNull();
+
+    act(() => {
+      store.dispatch(changeCurrentBufferAction(bufferId));
+    });
+
+    act(() => {
+      store.dispatch(
+        fetchLinesAction([
+          {
+            buffer: '86c417600',
+            date: '2024-04-05T02:40:09.000Z',
+            date_printed: '2024-04-06T17:20:30.000Z',
+            displayed: 1,
+            highlight: 0,
+            message: 'Second message',
+            pointers: ['86c417600', '8580eeec0', '8580dcc40', '86c2ff040'],
+            prefix: 'user',
+            tags_array: ['irc_privmsg', 'notify_message']
+          } as WeechatLine
+        ])
+      );
+    });
+
+    expect(ActualBuffer.prototype.componentDidUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ notificationLineId: '86c2ff040' }),
+      expect.anything(),
+      undefined
+    );
     expect(store.getState().app.notification).toBeNull();
   });
 });

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -15,21 +15,22 @@ export type AppState = {
   connected: boolean;
   currentBufferId: string | null;
   notification: { bufferId: string; lineId: string; identifier: string } | null;
-  notificationBufferLinesFetched: boolean;
+  currentBufferLinesFetched: boolean;
 };
 
 const initialState: AppState = {
   connected: false,
   currentBufferId: null,
   notification: null,
-  notificationBufferLinesFetched: false
+  currentBufferLinesFetched: false
 };
 
 export const app = createReducer(initialState, (builder) => {
   builder.addCase(disconnectAction, (state) => {
     return {
       ...state,
-      connected: false
+      connected: false,
+      currentBufferLinesFetched: false
     };
   });
   builder.addCase(fetchVersionAction, (state) => {
@@ -41,30 +42,29 @@ export const app = createReducer(initialState, (builder) => {
   builder.addCase(changeCurrentBufferAction, (state, action) => {
     return {
       ...state,
-      currentBufferId: action.payload
+      currentBufferId: action.payload,
+      currentBufferLinesFetched: false
     };
   });
   builder.addCase(fetchLinesAction, (state, action) => {
     return {
       ...state,
-      notificationBufferLinesFetched:
-        (state.notification &&
-          action.payload[0].buffer === state.notification.bufferId) ||
-        state.notificationBufferLinesFetched
+      currentBufferLinesFetched:
+        (state.currentBufferId &&
+          action.payload[0].buffer === state.currentBufferId) ||
+        state.currentBufferLinesFetched
     };
   });
   builder.addCase(bufferNotificationAction, (state, action) => {
     return {
       ...state,
-      notification: action.payload,
-      notificationBufferLinesFetched: false
+      notification: action.payload
     };
   });
   builder.addCase(clearBufferNotificationAction, (state) => {
     return {
       ...state,
-      notification: null,
-      notificationBufferLinesFetched: false
+      notification: null
     };
   });
   builder.addCase(bufferClosedAction, (state, action) => {

--- a/src/usecase/App.tsx
+++ b/src/usecase/App.tsx
@@ -159,11 +159,7 @@ class App extends React.Component<Props, State> {
       notification &&
       notification.identifier !== prevProps.notification?.identifier
     ) {
-      if (currentBufferId !== notification.bufferId)
-        this.changeCurrentBuffer(notification.bufferId);
-      else {
-        this.props.fetchBufferInfo(notification.bufferId);
-      }
+      this.changeCurrentBuffer(notification.bufferId);
 
       return;
     }

--- a/src/usecase/buffers/ui/BufferContainer.tsx
+++ b/src/usecase/buffers/ui/BufferContainer.tsx
@@ -34,7 +34,7 @@ const connector = connect((state: StoreState, { bufferId }: OwnProps) => ({
   mediaUploadOptions: state.connection.mediaUploadOptions,
   notification:
     bufferId === state.app.notification?.bufferId &&
-    state.app.notificationBufferLinesFetched
+    state.app.currentBufferLinesFetched
       ? state.app.notification
       : null
 }));
@@ -79,17 +79,6 @@ class BufferContainer extends React.Component<Props, State> {
   );
 
   buffer = React.createRef<Buffer>();
-
-  componentDidUpdate(prevProps: Readonly<Props>): void {
-    const { notification } = this.props;
-    if (
-      notification &&
-      notification.identifier !== prevProps.notification?.identifier
-    ) {
-      this.buffer.current?.scrollToLine(notification.lineId);
-      this.props.dispatch(clearBufferNotificationAction());
-    }
-  }
 
   handleOnFocus = () => {
     this.setState({
@@ -210,6 +199,10 @@ class BufferContainer extends React.Component<Props, State> {
     );
   };
 
+  clearNotification = () => {
+    this.props.dispatch(clearBufferNotificationAction());
+  };
+
   render() {
     const {
       bufferId,
@@ -217,7 +210,8 @@ class BufferContainer extends React.Component<Props, State> {
       showTopic,
       lines,
       fetchMoreLines,
-      mediaUploadOptions
+      mediaUploadOptions,
+      notification
     } = this.props;
     const { textValue, showTabButton } = this.state;
 
@@ -240,6 +234,8 @@ class BufferContainer extends React.Component<Props, State> {
           onLongPress={this.onLongPress}
           parseArgs={this.parseArgs}
           fetchMoreLines={fetchMoreLines}
+          notificationLineId={notification?.lineId}
+          clearNotification={this.clearNotification}
         />
         <View style={styles.bottomBox}>
           <UndoTextInput


### PR DESCRIPTION
When a notification is received for the current buffer and we're still connected (but in the background), new lines will already have loaded when the app resumes However, the lines may not have rendered yet, so they cannot be scrolled to reliably.

Work around this by changing the FlatList key, resetting its internal measurement state. Subsequent scroll will then either make it to the target or cycle trigger onScrollToIndexFailed.